### PR TITLE
Update for sdcc 4.2.3

### DIFF
--- a/fx2lafw.c
+++ b/fx2lafw.c
@@ -191,14 +191,14 @@ BOOL handle_set_configuration(BYTE cfg)
 	return (cfg == 1) ? TRUE : FALSE;
 }
 
-void sudav_isr(void) __interrupt SUDAV_ISR
+void sudav_isr(void) __interrupt(SUDAV_ISR)
 {
 	got_sud = TRUE;
 	CLEAR_SUDAV();
 }
 
 /* IN BULK NAK - the host started requesting data. */
-void ibn_isr(void) __interrupt IBN_ISR
+void ibn_isr(void) __interrupt(IBN_ISR)
 {
 	/*
 	 * If the IBN interrupt is not disabled, clearing
@@ -229,19 +229,19 @@ void ibn_isr(void) __interrupt IBN_ISR
 	SYNCDELAY();
 }
 
-void usbreset_isr(void) __interrupt USBRESET_ISR
+void usbreset_isr(void) __interrupt(USBRESET_ISR)
 {
 	handle_hispeed(FALSE);
 	CLEAR_USBRESET();
 }
 
-void hispeed_isr(void) __interrupt HISPEED_ISR
+void hispeed_isr(void) __interrupt(HISPEED_ISR)
 {
 	handle_hispeed(TRUE);
 	CLEAR_HISPEED();
 }
 
-void timer2_isr(void) __interrupt TF2_ISR
+void timer2_isr(void) __interrupt(TF2_ISR)
 {
 	/* Blink LED during acquisition, keep it on otherwise. */
 	if (gpif_acquiring == RUNNING) {

--- a/fx2lib/include/autovector.h
+++ b/fx2lib/include/autovector.h
@@ -172,49 +172,49 @@ typedef enum {
 // you must include the predef of these in the file with your main
 // so lets just define them here
 
-void sudav_isr() __interrupt SUDAV_ISR;
-void sof_isr() __interrupt SOF_ISR;
-void sutok_isr() __interrupt SUTOK_ISR;
-void suspend_isr() __interrupt SUSPEND_ISR;
-void usbreset_isr() __interrupt USBRESET_ISR;
-void hispeed_isr() __interrupt HISPEED_ISR;
-void ep0ack_isr() __interrupt EP0ACK_ISR;
-void ep0in_isr() __interrupt EP0IN_ISR;
-void ep0out_isr() __interrupt EP0OUT_ISR;
-void ep1in_isr() __interrupt EP1IN_ISR;
-void ep1out_isr() __interrupt EP1OUT_ISR;
-void ep2_isr() __interrupt EP2_ISR;
-void ep4_isr() __interrupt EP4_ISR;
-void ep6_isr() __interrupt EP6_ISR;
-void ep8_isr() __interrupt EP8_ISR;
-void ibn_isr() __interrupt IBN_ISR;
-void ep0ping_isr() __interrupt EP0PING_ISR;
-void ep1ping_isr() __interrupt EP1PING_ISR;
-void ep2ping_isr() __interrupt EP2PING_ISR;
-void ep4ping_isr() __interrupt EP4PING_ISR;
-void ep6ping_isr() __interrupt EP6PING_ISR;
-void ep8ping_isr() __interrupt EP8PING_ISR;
-void errlimit_isr() __interrupt ERRLIMIT_ISR;
-void ep2isoerr_isr() __interrupt EP2ISOERR_ISR;
-void ep4isoerr_isr() __interrupt EP4ISOERR_ISR;
-void ep6isoerr_isr() __interrupt EP6ISOERR_ISR;
-void ep8isoerr_isr() __interrupt EP8ISOERR_ISR;
-void spare_isr() __interrupt RESERVED_ISR; // not used
+void sudav_isr() __interrupt(SUDAV_ISR);
+void sof_isr() __interrupt(SOF_ISR);
+void sutok_isr() __interrupt(SUTOK_ISR);
+void suspend_isr() __interrupt(SUSPEND_ISR);
+void usbreset_isr() __interrupt(USBRESET_ISR);
+void hispeed_isr() __interrupt(HISPEED_ISR);
+void ep0ack_isr() __interrupt(EP0ACK_ISR);
+void ep0in_isr() __interrupt(EP0IN_ISR);
+void ep0out_isr() __interrupt(EP0OUT_ISR);
+void ep1in_isr() __interrupt(EP1IN_ISR);
+void ep1out_isr() __interrupt(EP1OUT_ISR);
+void ep2_isr() __interrupt(EP2_ISR);
+void ep4_isr() __interrupt(EP4_ISR);
+void ep6_isr() __interrupt(EP6_ISR);
+void ep8_isr() __interrupt(EP8_ISR);
+void ibn_isr() __interrupt(IBN_ISR);
+void ep0ping_isr() __interrupt(EP0PING_ISR);
+void ep1ping_isr() __interrupt(EP1PING_ISR);
+void ep2ping_isr() __interrupt(EP2PING_ISR);
+void ep4ping_isr() __interrupt(EP4PING_ISR);
+void ep6ping_isr() __interrupt(EP6PING_ISR);
+void ep8ping_isr() __interrupt(EP8PING_ISR);
+void errlimit_isr() __interrupt(ERRLIMIT_ISR);
+void ep2isoerr_isr() __interrupt(EP2ISOERR_ISR);
+void ep4isoerr_isr() __interrupt(EP4ISOERR_ISR);
+void ep6isoerr_isr() __interrupt(EP6ISOERR_ISR);
+void ep8isoerr_isr() __interrupt(EP8ISOERR_ISR);
+void spare_isr() __interrupt(RESERVED_ISR); // not used
 // gpif ints
-void ep2pf_isr() __interrupt EP2PF_ISR;
-void ep4pf_isr() __interrupt EP4PF_ISR;
-void ep6pf_isr() __interrupt EP6PF_ISR;
-void ep8pf_isr() __interrupt EP8PF_ISR;
-void ep2ef_isr() __interrupt EP2EF_ISR;
-void ep4ef_isr() __interrupt EP4EF_ISR;
-void ep6ef_isr() __interrupt EP6EF_ISR;
-void ep8ef_isr() __interrupt EP8EF_ISR;
-void ep2ff_isr() __interrupt EP2FF_ISR;
-void ep4ff_isr() __interrupt EP4FF_ISR;
-void ep6ff_isr() __interrupt EP6FF_ISR;
-void ep8ff_isr() __interrupt EP8FF_ISR;
-void gpifdone_isr() __interrupt GPIFDONE_ISR;
-void gpifwf_isr() __interrupt GPIFWF_ISR;
+void ep2pf_isr() __interrupt(EP2PF_ISR);
+void ep4pf_isr() __interrupt(EP4PF_ISR);
+void ep6pf_isr() __interrupt(EP6PF_ISR);
+void ep8pf_isr() __interrupt(EP8PF_ISR);
+void ep2ef_isr() __interrupt(EP2EF_ISR);
+void ep4ef_isr() __interrupt(EP4EF_ISR);
+void ep6ef_isr() __interrupt(EP6EF_ISR);
+void ep8ef_isr() __interrupt(EP8EF_ISR);
+void ep2ff_isr() __interrupt(EP2FF_ISR);
+void ep4ff_isr() __interrupt(EP4FF_ISR);
+void ep6ff_isr() __interrupt(EP6FF_ISR);
+void ep8ff_isr() __interrupt(EP8FF_ISR);
+void gpifdone_isr() __interrupt(GPIFDONE_ISR);
+void gpifwf_isr() __interrupt(GPIFWF_ISR);
 
 #endif
 

--- a/fx2lib/include/fx2regs.h
+++ b/fx2lib/include/fx2regs.h
@@ -266,14 +266,14 @@ __xdata __at 0xE50D volatile BYTE GPCR2;  ///< Chip Features
 
 __sfr __at 0x80 IOA;
          /*  IOA  */
-         __sbit __at 0x80 + 0 PA0;
-         __sbit __at 0x80 + 1 PA1;
-         __sbit __at 0x80 + 2 PA2;
-         __sbit __at 0x80 + 3 PA3;
-         __sbit __at 0x80 + 4 PA4;
-         __sbit __at 0x80 + 5 PA5;
-         __sbit __at 0x80 + 6 PA6;
-         __sbit __at 0x80 + 7 PA7;
+         __sbit __at (0x80+0) PA0;
+         __sbit __at (0x80+1) PA1;
+         __sbit __at (0x80+2) PA2;
+         __sbit __at (0x80+3) PA3;
+         __sbit __at (0x80+4) PA4;
+         __sbit __at (0x80+5) PA5;
+         __sbit __at (0x80+6) PA6;
+         __sbit __at (0x80+7) PA7;
 __sfr __at 0x81 SP;
 __sfr __at 0x82 DPL;
 __sfr __at 0x83 DPH;
@@ -283,14 +283,14 @@ __sfr __at 0x86 DPS;
 __sfr __at 0x87 PCON;
 __sfr __at 0x88 TCON;
          /*  TCON  */
-         __sbit __at 0x88+0 IT0;
-         __sbit __at 0x88+1 IE0;
-         __sbit __at 0x88+2 IT1;
-         __sbit __at 0x88+3 IE1;
-         __sbit __at 0x88+4 TR0;
-         __sbit __at 0x88+5 TF0;
-         __sbit __at 0x88+6 TR1;
-         __sbit __at 0x88+7 TF1;
+         __sbit __at (0x88+0) IT0;
+         __sbit __at (0x88+1) IE0;
+         __sbit __at (0x88+2) IT1;
+         __sbit __at (0x88+3) IE1;
+         __sbit __at (0x88+4) TR0;
+         __sbit __at (0x88+5) TF0;
+         __sbit __at (0x88+6) TR1;
+         __sbit __at (0x88+7) TF1;
 __sfr __at 0x89 TMOD;
 __sfr __at 0x8A TL0;
 __sfr __at 0x8B TL1;
@@ -299,28 +299,28 @@ __sfr __at 0x8D TH1;
 __sfr __at 0x8E CKCON;
 __sfr __at 0x90 IOB;
          /*  IOB  */
-         __sbit __at 0x90 + 0 PB0;
-         __sbit __at 0x90 + 1 PB1;
-         __sbit __at 0x90 + 2 PB2;
-         __sbit __at 0x90 + 3 PB3;
-         __sbit __at 0x90 + 4 PB4;
-         __sbit __at 0x90 + 5 PB5;
-         __sbit __at 0x90 + 6 PB6;
-         __sbit __at 0x90 + 7 PB7;
+         __sbit __at (0x90+0) PB0;
+         __sbit __at (0x90+1) PB1;
+         __sbit __at (0x90+2) PB2;
+         __sbit __at (0x90+3) PB3;
+         __sbit __at (0x90+4) PB4;
+         __sbit __at (0x90+5) PB5;
+         __sbit __at (0x90+6) PB6;
+         __sbit __at (0x90+7) PB7;
 __sfr __at 0x91 EXIF;
          
 //__sfr __at 0x92 MPAGE;
 __sfr __at 0x92 _XPAGE; // same as MPAGE for pdata __sfr access w/ sdcc
 __sfr __at 0x98 SCON0;
          /*  SCON0  */
-         __sbit __at 0x98+0 RI;
-         __sbit __at 0x98+1 TI;
-         __sbit __at 0x98+2 RB8;
-         __sbit __at 0x98+3 TB8;
-         __sbit __at 0x98+4 REN;
-         __sbit __at 0x98+5 SM2;
-         __sbit __at 0x98+6 SM1;
-         __sbit __at 0x98+7 SM0;
+         __sbit __at (0x98+0) RI;
+         __sbit __at (0x98+1) TI;
+         __sbit __at (0x98+2) RB8;
+         __sbit __at (0x98+3) TB8;
+         __sbit __at (0x98+4) REN;
+         __sbit __at (0x98+5) SM2;
+         __sbit __at (0x98+6) SM1;
+         __sbit __at (0x98+7) SM0;
 __sfr __at 0x99 SBUF0;
 
 __sfr __at 0x9A AUTOPTRH1; 
@@ -330,27 +330,27 @@ __sfr __at 0x9E AUTOPTRL2;
 
 __sfr __at 0xA0 IOC;
          /*  IOC  */
-         __sbit __at 0xA0 + 0 PC0;
-         __sbit __at 0xA0 + 1 PC1;
-         __sbit __at 0xA0 + 2 PC2;
-         __sbit __at 0xA0 + 3 PC3;
-         __sbit __at 0xA0 + 4 PC4;
-         __sbit __at 0xA0 + 5 PC5;
-         __sbit __at 0xA0 + 6 PC6;
-         __sbit __at 0xA0 + 7 PC7;
+         __sbit __at (0xA0+0) PC0;
+         __sbit __at (0xA0+1) PC1;
+         __sbit __at (0xA0+2) PC2;
+         __sbit __at (0xA0+3) PC3;
+         __sbit __at (0xA0+4) PC4;
+         __sbit __at (0xA0+5) PC5;
+         __sbit __at (0xA0+6) PC6;
+         __sbit __at (0xA0+7) PC7;
 __sfr __at 0xA1 INT2CLR;
 __sfr __at 0xA2 INT4CLR;
 
 __sfr __at 0xA8 IE;
          /*  IE  */
-         __sbit __at 0xA8+0 EX0;
-         __sbit __at 0xA8+1 ET0;
-         __sbit __at 0xA8+2 EX1;
-         __sbit __at 0xA8+3 ET1;
-         __sbit __at 0xA8+4 ES0;
-         __sbit __at 0xA8+5 ET2;
-         __sbit __at 0xA8+6 ES1;
-         __sbit __at 0xA8+7 EA;
+         __sbit __at (0xA8+0) EX0;
+         __sbit __at (0xA8+1) ET0;
+         __sbit __at (0xA8+2) EX1;
+         __sbit __at (0xA8+3) ET1;
+         __sbit __at (0xA8+4) ES0;
+         __sbit __at (0xA8+5) ET2;
+         __sbit __at (0xA8+6) ES1;
+         __sbit __at (0xA8+7) EA;
 
 __sfr __at 0xAA EP2468STAT;
 __sfr __at 0xAB EP24FIFOFLGS;
@@ -358,14 +358,14 @@ __sfr __at 0xAC EP68FIFOFLGS;
 __sfr __at 0xAF AUTOPTRSETUP;
 __sfr __at 0xB0 IOD;
          /*  IOD  */
-         __sbit __at 0xB0 + 0 PD0;
-         __sbit __at 0xB0 + 1 PD1;
-         __sbit __at 0xB0 + 2 PD2;
-         __sbit __at 0xB0 + 3 PD3;
-         __sbit __at 0xB0 + 4 PD4;
-         __sbit __at 0xB0 + 5 PD5;
-         __sbit __at 0xB0 + 6 PD6;
-         __sbit __at 0xB0 + 7 PD7;
+         __sbit __at (0xB0+0) PD0;
+         __sbit __at (0xB0+1) PD1;
+         __sbit __at (0xB0+2) PD2;
+         __sbit __at (0xB0+3) PD3;
+         __sbit __at (0xB0+4) PD4;
+         __sbit __at (0xB0+5) PD5;
+         __sbit __at (0xB0+6) PD6;
+         __sbit __at (0xB0+7) PD7;
 __sfr __at 0xB1 IOE;
 __sfr __at 0xB2 OEA;
 __sfr __at 0xB3 OEB;
@@ -375,13 +375,13 @@ __sfr __at 0xB6 OEE;
 
 __sfr __at 0xB8 IP;
          /*  IP  */
-         __sbit __at 0xB8+0 PX0;
-         __sbit __at 0xB8+1 PT0;
-         __sbit __at 0xB8+2 PX1;
-         __sbit __at 0xB8+3 PT1;
-         __sbit __at 0xB8+4 PS0;
-         __sbit __at 0xB8+5 PT2;
-         __sbit __at 0xB8+6 PS1;
+         __sbit __at (0xB8+0) PX0;
+         __sbit __at (0xB8+1) PT0;
+         __sbit __at (0xB8+2) PX1;
+         __sbit __at (0xB8+3) PT1;
+         __sbit __at (0xB8+4) PS0;
+         __sbit __at (0xB8+5) PT2;
+         __sbit __at (0xB8+6) PS1;
 
 __sfr __at 0xBA EP01STAT;
 __sfr __at 0xBB GPIFTRIG;
@@ -392,61 +392,61 @@ __sfr __at 0xBF GPIFSGLDATLNOX;
 
 __sfr __at 0xC0 SCON1;
          /*  SCON1  */
-         __sbit __at 0xC0+0 RI1;
-         __sbit __at 0xC0+1 TI1;
-         __sbit __at 0xC0+2 RB81;
-         __sbit __at 0xC0+3 TB81;
-         __sbit __at 0xC0+4 REN1;
-         __sbit __at 0xC0+5 SM21;
-         __sbit __at 0xC0+6 SM11;
-         __sbit __at 0xC0+7 SM01;
+         __sbit __at (0xC0+0) RI1;
+         __sbit __at (0xC0+1) TI1;
+         __sbit __at (0xC0+2) RB81;
+         __sbit __at (0xC0+3) TB81;
+         __sbit __at (0xC0+4) REN1;
+         __sbit __at (0xC0+5) SM21;
+         __sbit __at (0xC0+6) SM11;
+         __sbit __at (0xC0+7) SM01;
 __sfr __at 0xC1 SBUF1;
 __sfr __at 0xC8 T2CON;
          /*  T2CON  */
-         __sbit __at 0xC8+0 CP_RL2;
-         __sbit __at 0xC8+1 C_T2;
-         __sbit __at 0xC8+2 TR2;
-         __sbit __at 0xC8+3 EXEN2;
-         __sbit __at 0xC8+4 TCLK;
-         __sbit __at 0xC8+5 RCLK;
-         __sbit __at 0xC8+6 EXF2;
-         __sbit __at 0xC8+7 TF2;
+         __sbit __at (0xC8+0) CP_RL2;
+         __sbit __at (0xC8+1) C_T2;
+         __sbit __at (0xC8+2) TR2;
+         __sbit __at (0xC8+3) EXEN2;
+         __sbit __at (0xC8+4) TCLK;
+         __sbit __at (0xC8+5) RCLK;
+         __sbit __at (0xC8+6) EXF2;
+         __sbit __at (0xC8+7) TF2;
 __sfr __at 0xCA RCAP2L;
 __sfr __at 0xCB RCAP2H;
 __sfr __at 0xCC TL2;
 __sfr __at 0xCD TH2;
 __sfr __at 0xD0 PSW;
          /*  PSW  */
-         __sbit __at 0xD0+0 P;
-         __sbit __at 0xD0+1 FL;
-         __sbit __at 0xD0+2 OV;
-         __sbit __at 0xD0+3 RS0;
-         __sbit __at 0xD0+4 RS1;
-         __sbit __at 0xD0+5 F0;
-         __sbit __at 0xD0+6 AC;
-         __sbit __at 0xD0+7 CY;
+         __sbit __at (0xD0+0) P;
+         __sbit __at (0xD0+1) FL;
+         __sbit __at (0xD0+2) OV;
+         __sbit __at (0xD0+3) RS0;
+         __sbit __at (0xD0+4) RS1;
+         __sbit __at (0xD0+5) F0;
+         __sbit __at (0xD0+6) AC;
+         __sbit __at (0xD0+7) CY;
 __sfr __at 0xD8 EICON; // Was WDCON in DS80C320; Bit Values differ from Reg320
          /*  EICON  */
-         __sbit __at 0xD8+3 INT6;
-         __sbit __at 0xD8+4 RESI;
-         __sbit __at 0xD8+5 ERESI;
-         __sbit __at 0xD8+7 SMOD1;
+         __sbit __at (0xD8+3) INT6;
+         __sbit __at (0xD8+4) RESI;
+         __sbit __at (0xD8+5) ERESI;
+         __sbit __at (0xD8+7) SMOD1;
 __sfr __at 0xE0 ACC;
 __sfr __at 0xE8 EIE; // EIE Bit Values differ from Reg320
          /*  EIE  */
-         __sbit __at 0xE8+0 EUSB;
-         __sbit __at 0xE8+1 EI2C;
-         __sbit __at 0xE8+2 EIEX4;
-         __sbit __at 0xE8+3 EIEX5;
-         __sbit __at 0xE8+4 EIEX6;
+         __sbit __at (0xE8+0) EUSB;
+         __sbit __at (0xE8+1) EI2C;
+         __sbit __at (0xE8+2) EIEX4;
+         __sbit __at (0xE8+3) EIEX5;
+         __sbit __at (0xE8+4) EIEX6;
 __sfr __at 0xF0 B;
 __sfr __at 0xF8 EIP; // EIP Bit Values differ from Reg320
          /*  EIP  */
-         __sbit __at 0xF8+0 PUSB;
-         __sbit __at 0xF8+1 PI2C;
-         __sbit __at 0xF8+2 EIPX4;
-         __sbit __at 0xF8+3 EIPX5;
-         __sbit __at 0xF8+4 EIPX6;
+         __sbit __at (0xF8+0) PUSB;
+         __sbit __at (0xF8+1) PI2C;
+         __sbit __at (0xF8+2) EIPX4;
+         __sbit __at (0xF8+3) EIPX5;
+         __sbit __at (0xF8+4) EIPX6;
 
 
 /* CPU Control & Status Register (CPUCS) */

--- a/fx2lib/lib/interrupts/ep0ack_isr.c
+++ b/fx2lib/lib/interrupts/ep0ack_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep0ack_isr() __interrupt EP0ACK_ISR {}
+void ep0ack_isr() __interrupt(EP0ACK_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep0in_isr.c
+++ b/fx2lib/lib/interrupts/ep0in_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep0in_isr() __interrupt EP0IN_ISR {}
+void ep0in_isr() __interrupt(EP0IN_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep0out_isr.c
+++ b/fx2lib/lib/interrupts/ep0out_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep0out_isr() __interrupt EP0OUT_ISR {}
+void ep0out_isr() __interrupt(EP0OUT_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep0ping_isr.c
+++ b/fx2lib/lib/interrupts/ep0ping_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep0ping_isr() __interrupt EP0PING_ISR {}
+void ep0ping_isr() __interrupt(EP0PING_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep1in_isr.c
+++ b/fx2lib/lib/interrupts/ep1in_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep1in_isr() __interrupt EP1IN_ISR {}
+void ep1in_isr() __interrupt(EP1IN_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep1out_isr.c
+++ b/fx2lib/lib/interrupts/ep1out_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep1out_isr() __interrupt EP1OUT_ISR {}
+void ep1out_isr() __interrupt(EP1OUT_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep1ping_isr.c
+++ b/fx2lib/lib/interrupts/ep1ping_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep1ping_isr() __interrupt EP1PING_ISR {}
+void ep1ping_isr() __interrupt(EP1PING_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep2_isr.c
+++ b/fx2lib/lib/interrupts/ep2_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep2_isr() __interrupt EP2_ISR {}
+void ep2_isr() __interrupt(EP2_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep2ef_isr.c
+++ b/fx2lib/lib/interrupts/ep2ef_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep2ef_isr() __interrupt EP2EF_ISR{}
+void ep2ef_isr() __interrupt(EP2EF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep2ff_isr.c
+++ b/fx2lib/lib/interrupts/ep2ff_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep2ff_isr() __interrupt EP2FF_ISR{}
+void ep2ff_isr() __interrupt(EP2FF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep2isoerr_isr.c
+++ b/fx2lib/lib/interrupts/ep2isoerr_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep2isoerr_isr() __interrupt EP2ISOERR_ISR {}
+void ep2isoerr_isr() __interrupt(EP2ISOERR_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep2pf_isr.c
+++ b/fx2lib/lib/interrupts/ep2pf_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep2pf_isr() __interrupt EP2PF_ISR{}
+void ep2pf_isr() __interrupt(EP2PF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep2ping_isr.c
+++ b/fx2lib/lib/interrupts/ep2ping_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep2ping_isr() __interrupt EP2PING_ISR {}
+void ep2ping_isr() __interrupt(EP2PING_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep4_isr.c
+++ b/fx2lib/lib/interrupts/ep4_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep4_isr() __interrupt EP4_ISR {}
+void ep4_isr() __interrupt(EP4_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep4ef_isr.c
+++ b/fx2lib/lib/interrupts/ep4ef_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep4ef_isr() __interrupt EP4EF_ISR{}
+void ep4ef_isr() __interrupt(EP4EF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep4ff_isr.c
+++ b/fx2lib/lib/interrupts/ep4ff_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep4ff_isr() __interrupt EP4FF_ISR{}
+void ep4ff_isr() __interrupt(EP4FF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep4isoerr_isr.c
+++ b/fx2lib/lib/interrupts/ep4isoerr_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep4isoerr_isr() __interrupt EP4ISOERR_ISR {}
+void ep4isoerr_isr() __interrupt(EP4ISOERR_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep4pf_isr.c
+++ b/fx2lib/lib/interrupts/ep4pf_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep4pf_isr() __interrupt EP4PF_ISR{}
+void ep4pf_isr() __interrupt(EP4PF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep4ping_isr.c
+++ b/fx2lib/lib/interrupts/ep4ping_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep4ping_isr() __interrupt EP4PING_ISR {}
+void ep4ping_isr() __interrupt(EP4PING_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep6_isr.c
+++ b/fx2lib/lib/interrupts/ep6_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep6_isr() __interrupt EP6_ISR {}
+void ep6_isr() __interrupt(EP6_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep6ef_isr.c
+++ b/fx2lib/lib/interrupts/ep6ef_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep6ef_isr() __interrupt EP6EF_ISR{}
+void ep6ef_isr() __interrupt(EP6EF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep6ff_isr.c
+++ b/fx2lib/lib/interrupts/ep6ff_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep6ff_isr() __interrupt EP6FF_ISR{}
+void ep6ff_isr() __interrupt(EP6FF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep6isoerr_isr.c
+++ b/fx2lib/lib/interrupts/ep6isoerr_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep6isoerr_isr() __interrupt EP6ISOERR_ISR {}
+void ep6isoerr_isr() __interrupt(EP6ISOERR_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep6pf_isr.c
+++ b/fx2lib/lib/interrupts/ep6pf_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep6pf_isr() __interrupt EP6PF_ISR{}
+void ep6pf_isr() __interrupt(EP6PF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep6ping_isr.c
+++ b/fx2lib/lib/interrupts/ep6ping_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep6ping_isr() __interrupt EP6PING_ISR {}
+void ep6ping_isr() __interrupt(EP6PING_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep8_isr.c
+++ b/fx2lib/lib/interrupts/ep8_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep8_isr() __interrupt EP8_ISR {}
+void ep8_isr() __interrupt(EP8_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep8ef_isr.c
+++ b/fx2lib/lib/interrupts/ep8ef_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep8ef_isr() __interrupt EP8EF_ISR{}
+void ep8ef_isr() __interrupt(EP8EF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep8ff_isr.c
+++ b/fx2lib/lib/interrupts/ep8ff_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep8ff_isr() __interrupt EP8FF_ISR{}
+void ep8ff_isr() __interrupt(EP8FF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep8isoerr_isr.c
+++ b/fx2lib/lib/interrupts/ep8isoerr_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep8isoerr_isr() __interrupt EP8ISOERR_ISR {}
+void ep8isoerr_isr() __interrupt(EP8ISOERR_ISR) {}
 

--- a/fx2lib/lib/interrupts/ep8pf_isr.c
+++ b/fx2lib/lib/interrupts/ep8pf_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep8pf_isr() __interrupt EP8PF_ISR{}
+void ep8pf_isr() __interrupt(EP8PF_ISR){}
 

--- a/fx2lib/lib/interrupts/ep8ping_isr.c
+++ b/fx2lib/lib/interrupts/ep8ping_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ep8ping_isr() __interrupt EP8PING_ISR {}
+void ep8ping_isr() __interrupt(EP8PING_ISR) {}
 

--- a/fx2lib/lib/interrupts/errlimit_isr.c
+++ b/fx2lib/lib/interrupts/errlimit_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void errlimit_isr() __interrupt ERRLIMIT_ISR {}
+void errlimit_isr() __interrupt(ERRLIMIT_ISR) {}
 

--- a/fx2lib/lib/interrupts/gpifdone_isr.c
+++ b/fx2lib/lib/interrupts/gpifdone_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void gpifdone_isr() __interrupt GPIFDONE_ISR{}
+void gpifdone_isr() __interrupt(GPIFDONE_ISR){}
 

--- a/fx2lib/lib/interrupts/gpifwf_isr.c
+++ b/fx2lib/lib/interrupts/gpifwf_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void gpifwf_isr() __interrupt GPIFWF_ISR{}
+void gpifwf_isr() __interrupt(GPIFWF_ISR){}
 

--- a/fx2lib/lib/interrupts/hispeed_isr.c
+++ b/fx2lib/lib/interrupts/hispeed_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void hispeed_isr() __interrupt HISPEED_ISR {}
+void hispeed_isr() __interrupt(HISPEED_ISR) {}
 

--- a/fx2lib/lib/interrupts/ibn_isr.c
+++ b/fx2lib/lib/interrupts/ibn_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void ibn_isr() __interrupt IBN_ISR {}
+void ibn_isr() __interrupt(IBN_ISR) {}
 

--- a/fx2lib/lib/interrupts/sof_isr.c
+++ b/fx2lib/lib/interrupts/sof_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void sof_isr() __interrupt SOF_ISR {}
+void sof_isr() __interrupt(SOF_ISR) {}
 

--- a/fx2lib/lib/interrupts/spare_isr.c
+++ b/fx2lib/lib/interrupts/spare_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void spare_isr() __interrupt RESERVED_ISR {}
+void spare_isr() __interrupt(RESERVED_ISR) {}
 

--- a/fx2lib/lib/interrupts/sudav_isr.c
+++ b/fx2lib/lib/interrupts/sudav_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void sudav_isr() __interrupt SUDAV_ISR {}
+void sudav_isr() __interrupt(SUDAV_ISR) {}
 

--- a/fx2lib/lib/interrupts/suspend_isr.c
+++ b/fx2lib/lib/interrupts/suspend_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void suspend_isr() __interrupt SUSPEND_ISR {}
+void suspend_isr() __interrupt(SUSPEND_ISR) {}
 

--- a/fx2lib/lib/interrupts/sutok_isr.c
+++ b/fx2lib/lib/interrupts/sutok_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void sutok_isr() __interrupt SUTOK_ISR {}
+void sutok_isr() __interrupt(SUTOK_ISR) {}
 

--- a/fx2lib/lib/interrupts/usbreset_isr.c
+++ b/fx2lib/lib/interrupts/usbreset_isr.c
@@ -17,5 +17,5 @@
 
 #include <autovector.h>
 
-void usbreset_isr() __interrupt USBRESET_ISR {}
+void usbreset_isr() __interrupt(USBRESET_ISR) {}
 

--- a/include/scope.inc
+++ b/include/scope.inc
@@ -43,36 +43,36 @@ static volatile __bit dosuspend = FALSE;
 extern __code BYTE highspd_dscr;
 extern __code BYTE fullspd_dscr;
 
-void resume_isr(void) __interrupt RESUME_ISR
+void resume_isr(void) __interrupt(RESUME_ISR)
 {
 	CLEAR_RESUME();
 }
 
-void sudav_isr(void) __interrupt SUDAV_ISR
+void sudav_isr(void) __interrupt(SUDAV_ISR)
 {
 	dosud = TRUE;
 	CLEAR_SUDAV();
 }
 
-void usbreset_isr(void) __interrupt USBRESET_ISR
+void usbreset_isr(void) __interrupt(USBRESET_ISR)
 {
 	handle_hispeed(FALSE);
 	CLEAR_USBRESET();
 }
 
-void hispeed_isr(void) __interrupt HISPEED_ISR
+void hispeed_isr(void) __interrupt(HISPEED_ISR)
 {
 	handle_hispeed(TRUE);
 	CLEAR_HISPEED();
 }
 
-void suspend_isr(void) __interrupt SUSPEND_ISR
+void suspend_isr(void) __interrupt(SUSPEND_ISR)
 {
 	dosuspend = TRUE;
 	CLEAR_SUSPEND();
 }
 
-void timer2_isr(void) __interrupt TF2_ISR
+void timer2_isr(void) __interrupt(TF2_ISR)
 {
 	/* Toggle the probe calibration pin, only accurate up to ca. 8MHz. */
 	TOGGLE_CALIBRATION_PIN();


### PR DESCRIPTION
Fix non-parenthesized arguments to __interrupt and __at to be compatible with sdcc>=4.2.3

> In 4.2.3, support for non-parenthesized arguments to __using and
> __interrupt was dropped.

> In 4.2.3, support for non-parenthesized arguments to __at that are
> not constants was dropped.

-- https://sdcc.sourceforge.net/doc/sdccman.pdf §1.5, pg11,12